### PR TITLE
got rid of the commented out function for this

### DIFF
--- a/app/src/main/java/com/example/chrono/util/BaseActivity.kt
+++ b/app/src/main/java/com/example/chrono/util/BaseActivity.kt
@@ -10,7 +10,6 @@ import com.example.chrono.util.objects.CircuitsObject
 import com.example.chrono.util.objects.PreferenceManager
 
 open class BaseActivity : AppCompatActivity() {
-
     var circuits: CircuitsObject? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,19 +23,6 @@ open class BaseActivity : AppCompatActivity() {
             circuits = CircuitsObject()
             PreferenceManager.put(circuits, "CIRCUITS")
         }
-        // The code to mess around with the status bar, only works on KitKat and onwards
-        // If it's after KitKat we change the color of the status bar, else we just make it invisible
-//        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-//            val w: Window = window
-//            w.setFlags(
-//                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-//                WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
-//            )
-//            val decor = window.decorView
-//            decor.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-//        } else {
-//            setStatusBarInvisible()
-//        }
     }
 
     public override fun onSaveInstanceState(state: Bundle) {


### PR DESCRIPTION
Story: https://app.clubhouse.io/chrono/story/58/configure-status-bar

Looks fine the way it is right now. If we really want to we can try harder to make the status bar "transparent" in the future but right now no need to fix what isn't broke. I got rid of the existing logic which was commented out anyways. Even if we wanted to use this it's deprecated so it would have to be changed regardless.