### PR TITLE
Svdesu/ch314/restart circuit seems broken

### DIFF
--- a/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
+++ b/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
@@ -285,8 +285,6 @@ class CircuitTimerActivity : BaseActivity() {
                 bind.initButtonLayout.visibility = View.GONE
                 bind.runButtonLayout.visibility = View.VISIBLE
                 bind.pauseButtonLayout.visibility = View.GONE
-
-                bind.pauseButton.setTextColor(ContextCompat.getColor(this, R.color.lightText))
             }
             TimerState.PAUSED -> {
                 bind.initButtonLayout.visibility = View.GONE

--- a/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
+++ b/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
@@ -126,7 +126,6 @@ class CircuitTimerActivity : BaseActivity() {
                 if ((p0.toFloat().roundToInt() / 1000.0f) != secondsLeft) {
                     secondsLeft = (p0.toFloat() / 1000.0f).roundToInt().toFloat()
                     updateTimerUI()
-//                    createNotification(secondsLeft)
                 }
             }
 

--- a/app/src/main/res/layout/activity_circuit_timer.xml
+++ b/app/src/main/res/layout/activity_circuit_timer.xml
@@ -116,6 +116,7 @@
                     android:letterSpacing="0"
                     android:text="@string/pause"
                     android:textAllCaps="false"
+                    android:textColor="@color/lightText"
                     android:textSize="@dimen/xl_medium_text"
                     android:textStyle="bold"
                     app:cornerRadius="13dp" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
     <color name="lightTextSecondary">#6F6F6F</color>
 
     <!-- Dark Mode Colors -->
+    <color name="darkBackground">#121212</color>
     <color name="darkText">#DBDBDB</color>
     <color name="darkTextSecondary">#AFAFAF</color>
 


### PR DESCRIPTION
Stories:
https://app.clubhouse.io/chrono/story/314/restart-circuit-seems-broken
https://app.clubhouse.io/chrono/story/311/dark-mode-missing-implementations

**What I did:**
- Fixed the restart circuit stuff. This is a bit of a workaround but honestly way easier than what we were doing before. We simply restart the activity itself. It work and with a few animations it looks pretty good too.
- When you press pause/stop the background + colors actually respond to dark mode settings now (previously they were all basically light mode). 
- Pause button text color fixed.