### PR TITLE
Fix bug circuit complete dialog title cut.

### DIFF
--- a/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
+++ b/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
@@ -8,7 +8,10 @@ import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.SoundPool
 import android.media.ToneGenerator
-import android.os.*
+import android.os.Bundle
+import android.os.CountDownTimer
+import android.os.Handler
+import android.os.Looper
 import android.transition.Fade
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/res/layout/dialog_alert.xml
+++ b/app/src/main/res/layout/dialog_alert.xml
@@ -12,11 +12,10 @@
             android:id="@+id/dialog_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:ellipsize="end"
             android:lines="1"
             android:maxLines="1"
             android:padding="@dimen/small_element_padding"
-            android:text="@string/delete_circuit"
+            android:text="@string/todo"
             android:textSize="@dimen/xl_large_text"
             android:textStyle="bold" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,7 +42,7 @@
     <string name="cancel">Cancel</string>
 
     <!-- Circuit Complete Dialog -->
-    <string name="circuit_complete">Circuit Complete 🥳🥳🥳</string>
+    <string name="circuit_complete">Circuit Complete🥳🥳🥳</string>
     <string name="circuit_complete_subtitle">Woohoo! You have completed your circuit, good job!!!</string>
     <string name="circuit_complete_confirm">Finish</string>
     <string name="circuit_complete_cancel">Restart</string>


### PR DESCRIPTION
**Clubhouse Story:** https://app.clubhouse.io/chrono/story/371/circuit-finish-dialog



**What does this PR solve?**

- In smaller screens, the circuit complete alert dialog gets truncated replacing emojis with "..." 's instead.
- The fix removes removes characters that do not fit in the screen without adding the "...". 
![image](https://user-images.githubusercontent.com/22647864/118906380-b3e6ba00-b8eb-11eb-9f4c-741d479bcdcb.png)


**List the steps to take to replicate the behaviour introduced by this PR**

- Create an emulator for an s9, s7 (basically any old phone that has a lower dpi and has weird dimensions). Create and start a circuit. Issue should be observed in the circuit complete celebration page.


**List any known issues that this PR brings about**

- If the screen is extremely small, text could be cut off without the "...". One way to fix this is to remove the one line restriction. The issue with that is only the emojis are moved to the next line, not the whole word (look at image below). Alternatively we could just add one emoji at the front and one at the end, but i personally like the 3 party emojis. 
![image](https://user-images.githubusercontent.com/22647864/118906084-08d60080-b8eb-11eb-99ea-1d4544a46160.png)




**What's something funny/stupid that happened when working on this story?**

- Samsung had some fucked up screen resolutions and ratios. Like wtf, 2960 x 1440p. This is the kind of shit we would laugh at in Ross.


**Other information**



**Please check if the PR fulfills these requirements**
- [ x] The commit messages follows our guidelines
- [x ] All errors and warnings have been taken care of
