### PR TITLE
Svdesu/ch435/timer layout glitch

### DIFF
--- a/android/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
+++ b/android/app/src/main/java/ca/chronofit/chrono/circuit/CircuitTimerActivity.kt
@@ -371,7 +371,7 @@ class CircuitTimerActivity : BaseActivity() {
             RunningState.WORK -> {
                 bind.currentState.text = getString(R.string.workout)
                 bind.currentSet.text = "Set " + (sets - currentSet.toString().toInt() + 1)
-                bind.closeButton.visibility = View.GONE
+                bind.closeButton.visibility = View.INVISIBLE
                 bind.mainLayout.setBackgroundColor(
                     ContextCompat.getColor(
                         this,

--- a/android/app/src/main/res/layout/activity_circuit_timer.xml
+++ b/android/app/src/main/res/layout/activity_circuit_timer.xml
@@ -35,11 +35,10 @@
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/current_state"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
+                    android:gravity="center"
                     android:layout_marginHorizontal="@dimen/medium_element_padding"
-                    android:layout_marginVertical="@dimen/medium_element_padding"
                     android:fontFamily="@font/nunito_bold"
                     android:text="@string/lets_go"
                     android:textAllCaps="true"


### PR DESCRIPTION
**Clubhouse Story:**
https://app.clubhouse.io/chrono/story/435/timer-layout-glitch


**What does this PR solve?**
- There was this "glitch" where if you're in a circuit, pressing pause causes most of the elements on the screen to shift slightly either up/down. The reason for this was that we set the "X" button (`closeButton`)'s visibilty to `GONE `instead of `INVISIBLE`. Other elements in that view are relative to the close button, setting it's visibility to `GONE `means it's completely gone from the view. `INVISIBLE `means we can't see it but it's still _there_. This fixes it.
- Noticed when testing on a S8 that the "GET READY" text wasn't centered so quickly fixed it.

**List the steps to take to replicate the behavior introduced by this PR**
- Create any kind of circuit and run it. Keep pressing pause/play and see if there's any discrepancies in the layout. Keep in mind if testing on a S8/S9, the "Get Ready" text appears on two lines, so when the "Workout" starts, since the text only occupies one line things shift up. For now we'll just let this be since this view will be redone next Sprint.


**List any known issues that this PR brings about**
- None.


**What's something funny/stupid that happened when working on this story?**
- Realizing how much work the timer screen needs.


**Other information**
- None.


**Please check if the PR fulfills these requirements**
- [x] The commit messages follows our guidelines
- [x] All errors and warnings have been taken care of
